### PR TITLE
Add cookbook name to metadata

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "control_groups"
 maintainer       "Heavy Water"
 maintainer_email "support@hw-ops.com"
 license          "Apache 2.0"


### PR DESCRIPTION
Recent versions of Ridley and Berkshelf choke on cookbook dependencies that do not have a 'name' property specified.